### PR TITLE
Bronte/project table 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,28 @@ RUN python3 -m pip install slims-python-api
 # The following lines are needed to ensure your build environement works
 # correctly with latch.
 RUN python3 -m pip install --upgrade latch
-COPY wf /root/wf
-ARG tag
-ENV FLYTE_INTERNAL_IMAGE $tag
-WORKDIR /root
+# RUN python3 -m pip install latch==2.35.0
 
+# COPY wf /root/wf
+# ARG tag
+# ENV FLYTE_INTERNAL_IMAGE $tag
+# WORKDIR /root
+
+# root@c8b976277765:~# python3 -m pip install latch --upgrade
+#### NEWWWW BELOW
+# Latch SDK
+# DO NOT REMOVE
+run pip install latch==2.36.3
+run mkdir /opt/latch
+
+# Copy workflow data (use .dockerignore to skip files)
+copy . .latch/* /root/
+
+
+# Latch workflow registration metadata
+# DO NOT CHANGE
+arg tag
+# DO NOT CHANGE
+env FLYTE_INTERNAL_IMAGE $tag
+
+workdir /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,23 +53,13 @@ RUN python3 -m pip install slims-python-api
 # The following lines are needed to ensure your build environement works
 # correctly with latch.
 RUN python3 -m pip install --upgrade latch
-# RUN python3 -m pip install latch==2.35.0
 
-# COPY wf /root/wf
-# ARG tag
-# ENV FLYTE_INTERNAL_IMAGE $tag
-# WORKDIR /root
-
-# root@c8b976277765:~# python3 -m pip install latch --upgrade
-#### NEWWWW BELOW
-# Latch SDK
 # DO NOT REMOVE
 run pip install latch==2.36.3
 run mkdir /opt/latch
 
 # Copy workflow data (use .dockerignore to skip files)
 copy . .latch/* /root/
-
 
 # Latch workflow registration metadata
 # DO NOT CHANGE

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -11,8 +11,9 @@ import subprocess
 from enum import Enum
 from pathlib import Path
 from typing import List
+from latch.registry.table import Table
 
-from latch import large_task, small_task, workflow
+from latch import large_task, small_task, workflow, custom_task
 from latch.resources.launch_plan import LaunchPlan
 from latch.types import (
     LatchAuthor,
@@ -24,7 +25,7 @@ from latch.types import (
 )
 
 import wf.lims as lims
-from wf.registry import Run, upload_to_registry
+from wf.registry import Run, upload_to_registry, Project, initialize_runs
 
 
 class Genome(Enum):
@@ -32,9 +33,10 @@ class Genome(Enum):
     hg38 = 'hg38'
 
 
-@large_task
+@custom_task(cpu=62, memory=384, storage_gib=500)
+# @large_task
 def archr_task(
-    runs: List[Run],
+    projects: List[Project],
     project_name: str,
     genome: Genome,
     tile_size: int,
@@ -44,9 +46,13 @@ def archr_task(
     lsi_resolution: List[float],
     lsi_varfeatures: List[int],
     clustering_resolution: List[float],
-    umap_mindist: float
+    umap_mindist: float,
+    project_table_id: str,
+    run_table_id: str,
 ) -> LatchDir:
 
+    runs =[]
+    runs=initialize_runs(projects, project_table_id, run_table_id)
     _archr_cmd = [
         'Rscript',
         '/root/wf/archr_objs.R',
@@ -65,19 +71,18 @@ def archr_task(
     runs = [
         (
             f'{run.run_id},'
-            f'{run.fragments_file.local_path},'
+            f'{run.fragments_file},'
             f'{run.condition},'
-            f'{run.positions_file.local_path},'
-            f'{run.spatial_dir.local_path},'
+            f'{run.positions_file},'
+            f'{run.spatial_dir},'
             )
         for run in runs
     ]
 
     _archr_cmd.extend(runs)
     subprocess.run(_archr_cmd)
-
     out_dir = project_name
-    subprocess.run(['mkdir', out_dir])
+    mkdir(out_dir)
 
     figures = glob.glob('*_plots.pdf')
 
@@ -153,8 +158,8 @@ metadata = LatchMetadata(
     repository='https://github.com/atlasxomics/archr_latch',
     license='MIT',
     parameters={
-        'runs': LatchParameter(
-            display_name='runs',
+        'projects': LatchParameter(
+            display_name='projects',
             description='List of runs to be analyzed; each run must contain a \
                          run_id and fragments.tsv file; optional: condition, \
                          tissue position file for filtering on/off tissue, \
@@ -255,11 +260,11 @@ metadata = LatchMetadata(
 
 @workflow(metadata)
 def archr_workflow(
-    runs: List[Run],
+    projects: List[Project],
     genome: Genome,
     project_name: str,
     run_table_id: str = "761",
-    project_table_id: str = "779",
+    project_table_id: str = "917",
     upload: bool = False,
     tile_size: int = 5000,
     min_TSS: float = 2.0,
@@ -288,9 +293,10 @@ def archr_workflow(
     [Seurat](https://satijalab.org/seurat/)
     to spatially align the data.  The workflow can take data from either a
     single tissue-sample analyzed via DBiT-seq or multiple tissue-samples; in
-    ATX parlance, tissue-samples analyzed via DBIT-seq are termed 'Runs'.  All
-    Runs input to **optimize archr** are merged into a single ArchRProject for
-    analysis.
+    ATX parlance, tissue-samples analyzed via DBIT-seq are termed 'Runs'. Multiple Runs are linked
+    to a Project, which is the input into **optimize archr**. All
+    Runs inputted to **optimize archr** through Project(s) are merged into a single ArchRProject for
+    analysis. 
 
     ## Inputs
     All input files for **optimize archr** must be on the latch.bio
@@ -314,7 +320,7 @@ def archr_workflow(
     * Condition (_optional_):  An experimental Condition descriptor (ie.
     'control', 'diseased')
 
-    Individual runs are batched in a Project with the following global
+    Individual runs are linked to a Project, which are all batched with the following global
     parameters,
 
     * Project Name: A name for the output folder
@@ -354,8 +360,8 @@ def archr_workflow(
     your latch.bio workspace.  Ensure you are on the 'Parameters' tab of the
     workflow.
 
-    2. To add Runs to the Project, select the '+ runs' icon.  Add values for
-    the Run parameters described above; repeat for each Run in the Project.
+    2. To add Projects to the workflow, select the '+ Import from Registry' icon.  Select the Project(s)
+    that are linked to the Runs you want to process. Repeat for each Project you want to add to the workflow.
 
     3. Scroll to the bottom of the page and input values for global project
     parameters.
@@ -376,7 +382,6 @@ def archr_workflow(
     7. Workflow outputs are loaded into the latch.bio
     [Data module](https://wiki.latch.bio/wiki/data/overview) in the
     `optimize_outs` directory.
-
 
     ## Outputs
 
@@ -434,7 +439,7 @@ def archr_workflow(
     '''
 
     results_dir = archr_task(
-        runs=runs,
+        projects=projects,
         project_name=project_name,
         genome=genome,
         tile_size=tile_size,
@@ -444,11 +449,13 @@ def archr_workflow(
         lsi_resolution=lsi_resolution,
         lsi_varfeatures=lsi_varfeatures,
         clustering_resolution=clustering_resolution,
-        umap_mindist=umap_mindist
+        umap_mindist=umap_mindist,
+        project_table_id=project_table_id,
+        run_table_id=run_table_id
     )
 
     upload_to_registry(
-        runs=runs,
+        projects=projects,
         archr_project=results_dir,
         run_table_id=run_table_id,
         project_table_id=project_table_id
@@ -461,19 +468,33 @@ LaunchPlan(
     archr_workflow,
     'defaults',
     {
-    'runs': [
-        Run(
-            'default',
-            LatchFile('latch:///atac_outs/demo/outs/demo_fragments.tsv.gz'),
-            'demo',
-            LatchDir('latch:///spatials/demo/spatial'),
-            LatchFile('latch:///spatials/demo/spatial/tissue_positions_list.csv'),
+    'projects' : [
+        Project(
+            'demo_row_archr', False
             )
         ],
-        'project_name': 'demo',
-        'genome': Genome.hg38,
-        'upload': False,
-        'run_table_id': '761',
-        'project_table_id': '779'
+    'project_name' : 'demo',
+    'genome' : Genome.hg38,
+    'run_table_id': '761',
+    'project_table_id': '917',
     },
 )
+
+# if __name__ == "__main__":
+#     archr_task(
+#         projects=[Project(
+#             project_id="example_proj_opt",
+#             cleaned_frag_file=False
+#         )],
+#         project_name="test",
+#         genome=Genome["mm10"],
+#         tile_size=5000,
+#         min_TSS=2.0,
+#         min_frags=0,
+#         lsi_iterations=2,
+#         lsi_resolution=[0.5],
+#         lsi_varfeatures=[25000],
+#         clustering_resolution=[1.0],
+#         umap_mindist=0.0,
+#         project_table_id="922"
+#     )

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -82,7 +82,7 @@ def archr_task(
     _archr_cmd.extend(runs)
     subprocess.run(_archr_cmd)
     out_dir = project_name
-    mkdir(out_dir)
+    msubprocess.run(['mkdir', f'{out_dir}'])
 
     figures = glob.glob('*_plots.pdf')
 

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -82,8 +82,9 @@ def archr_task(
     _archr_cmd.extend(runs)
     subprocess.run(_archr_cmd)
     out_dir = project_name
-    msubprocess.run(['mkdir', f'{out_dir}'])
-
+    mkdir_cmd = ['mkdir'] + [out_dir]
+    subprocess.run(mkdir_cmd)
+    
     figures = glob.glob('*_plots.pdf')
 
     _mv_cmd = ['mv'] + figures + ['medians.csv'] + [out_dir]

--- a/wf/registry.py
+++ b/wf/registry.py
@@ -76,27 +76,33 @@ def upload_to_registry(
     run_table = Table(run_table_id)
     project_table = Table(project_table_id)
     runs=initialize_runs(projects, project_table_id, run_table_id)
+
     try:
+        
+        with project_table.update() as updater:
+            for p in projects:
+                message(
+                    "info",
+                    {
+                        "title": f"Updating run {p.project_id} in registry table ID {project_table_id}",
+                        "body": "",
+                    },
+                )
+
+                updater.upsert_record(
+                    p.project_id,
+                    optimize_outs=archr_project
+                )
         with run_table.update() as updater:
             for run in runs:
                 message(
                     "info",
                     {
                         "title": f"Updating run {run.run_id} in registry table ID {run_table_id}",
-                        "body": f"Run {run.run_id}, condition {run.condition}",
+                        "body": "",
                     },
                 )
 
-                updater.upsert_record(
-                    run.run_id,
-                    condition=run.condition,
-                    spatial_directory=run.spatial_dir,
-                    positions_file=run.positions_file,
-                    optimize_outs=archr_project
-                )
-        
-        with project_table.update() as updater:
-            for run in runs:
                 updater.upsert_record(
                     run.run_id,
                     optimize_outs=archr_project

--- a/wf/registry.py
+++ b/wf/registry.py
@@ -12,7 +12,7 @@ logging.basicConfig(format="%(levelname)s - %(asctime)s - %(message)s")
 @dataclass
 class Run:
     run_id: str
-    fragments_file: LatchFile
+    fragments_file: str
     condition: str = 'None'
     spatial_dir: LatchDir = LatchDir(
         'latch:///spatials/demo/spatial/'
@@ -21,15 +21,61 @@ class Run:
         'latch:///spatials/demo/spatial/tissue_positions_list.csv'
     )
 
+@dataclass
+class Project:
+    project_id: str
+    cleaned_frag_file: bool
+
+def initialize_runs(projects: List[Project], project_table_id: str, run_table_id: str) -> List[Run]:
+    runs = []
+    project_table=Table(project_table_id)
+    run_table=Table(run_table_id)
+    try:
+        for p in projects:
+            for page in project_table.list_records(): 
+                for p_id, record in page.items():
+                    p_id = record.get_name()
+                    if p_id == p.project_id:
+                        project = record.get_values()
+                        try:
+                            if len(project['Runs']) > 0:
+                                for project_run in project['Runs']:
+                                    run_info = project_run.get_values()
+                                    run_id = project_run.get_name()
+                                    try:
+                                        if p.cleaned_frag_file:
+                                            run_fragments_file = run_info['cleaned_fragment_file']
+                                        else:   
+                                            run_fragments_file = run_info['fragments_file']
+                                        try:
+                                            run_condition = run_info['condition']
+                                        except:
+                                            run_condition = ""
+                                        run_spatial_dir = run_info['spatial_directory']
+                                        run_positions_file = run_info['positions_file']
+                                        run_fragments_file = LatchFile(run_fragments_file.local_path, run_fragments_file.local_path).local_path
+                                        run_positions_file = LatchFile(run_positions_file.local_path, run_positions_file.local_path).local_path
+                                        run_spatial_dir = LatchDir(run_spatial_dir.local_path, run_spatial_dir.local_path).local_path
+                                        runs.append(Run(run_id, run_fragments_file, run_condition, run_spatial_dir, run_positions_file))
+                                    except:
+                                        print(f"Data missing for run: {run_id}")
+                        except:
+                            break
+        return runs
+    except Exception as err:
+        print(f"Unexpected {err=}, {type(err)=}")
+        return
+
 @small_task(retries=0)
 def upload_to_registry(
-    runs: List[Run],
+    projects: List[Project],
     archr_project: LatchDir,
     run_table_id: str = "761",
-    project_table_id: str = "779"
+    project_table_id: str = "917"
 ):
     run_table = Table(run_table_id)
     project_table = Table(project_table_id)
+    runs=initialize_runs(projects)
     try:
         with run_table.update() as updater:
             for run in runs:
@@ -62,39 +108,39 @@ def upload_to_registry(
         return
 
 
-if __name__ == "__main__":
-    upload_to_registry(
-        runs=[
-            Run(
-                'D1291',
-                LatchFile('latch:///atac_outs/6bp_D01291_NG02620/outs/6bp_D01291_NG02620_fragments.tsv.gz'),
-                'old',
-                LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1291/spatial'),
-                LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1291/spatial/tissue_positions_list.csv'),
-            ),
-            Run(
-                'D1292',
-                LatchFile('latch:///cleaned/Babayev_cleaned/cleaned_D01292_NG02621_fragments.tsv.gz'),
-                'old',
-                LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1292/spatial'),
-                LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1292/spatial/tissue_positions_list.csv')
-            ),
-            Run(
-                'D1293',
-                LatchFile('latch:///atac_outs/6bp_D01293_NG02622/outs/6bp_D01293_NG02622_fragments.tsv.gz'),
-                'young',
-                LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1293/spatial'),
-                LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1293/spatial/tissue_positions_list.csv')
-            ),
-            Run(
-                'D1294',
-                LatchFile('latch:///atac_outs/D01294_NG02624/outs/D01294_NG02624_fragments.tsv.gz'),
-                'young',
-                LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1294/spatial'),
-                LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1294/spatial/tissue_positions_list.csv')
-            )
-        ],
-        archr_project=LatchDir("latch://13502.account/ArchRProjects/Babeyev"),
-        run_table_id="761",
-        project_table_id="779"
-    )
+# if __name__ == "__main__":
+#     upload_to_registry(
+#         runs=[
+#             Run(
+#                 'D1291',
+#                 LatchFile('latch:///atac_outs/6bp_D01291_NG02620/outs/6bp_D01291_NG02620_fragments.tsv.gz'),
+#                 'old',
+#                 LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1291/spatial'),
+#                 LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1291/spatial/tissue_positions_list.csv'),
+#             ),
+#             Run(
+#                 'D1292',
+#                 LatchFile('latch:///cleaned/Babayev_cleaned/cleaned_D01292_NG02621_fragments.tsv.gz'),
+#                 'old',
+#                 LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1292/spatial'),
+#                 LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1292/spatial/tissue_positions_list.csv')
+#             ),
+#             Run(
+#                 'D1293',
+#                 LatchFile('latch:///atac_outs/6bp_D01293_NG02622/outs/6bp_D01293_NG02622_fragments.tsv.gz'),
+#                 'young',
+#                 LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1293/spatial'),
+#                 LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1293/spatial/tissue_positions_list.csv')
+#             ),
+#             Run(
+#                 'D1294',
+#                 LatchFile('latch:///atac_outs/D01294_NG02624/outs/D01294_NG02624_fragments.tsv.gz'),
+#                 'young',
+#                 LatchDir('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1294/spatial'),
+#                 LatchFile('latch:///atx-illumina-1682977469.0200825/Images_spatial/D1294/spatial/tissue_positions_list.csv')
+#             )
+#         ],
+#         archr_project=LatchDir("latch://13502.account/ArchRProjects/Babeyev"),
+#         run_table_id="761",
+#         project_table_id="779"
+#     )

--- a/wf/registry.py
+++ b/wf/registry.py
@@ -75,7 +75,7 @@ def upload_to_registry(
 ):
     run_table = Table(run_table_id)
     project_table = Table(project_table_id)
-    runs=initialize_runs(projects)
+    runs=initialize_runs(projects, project_table_id, run_table_id)
     try:
         with run_table.update() as updater:
             for run in runs:


### PR DESCRIPTION
**Integration with Projects Table**

- The _optimize archr_ workflow has been updated to have a list of Projects as input to the workflow, instead of a list of Runs.
- A Project is linked to multiple runs in a column in Latch Registry. When a Project is inputted into the workflow, all Runs linked to it are batched together. Multiple Projects can be added, the Runs for which will all be batched together.
- For each Project, a boolean flag is also passed to confirm if cleaned fragment files column for its linked runs will be used in the workflow. This user should set this flag in the projects table for the Project of interest.

